### PR TITLE
Fix failure on windows onCreate

### DIFF
--- a/volofile
+++ b/volofile
@@ -30,7 +30,7 @@ define(function (require) {
                 })
                 .then(function () {
                     //Move the JS to the right location.
-                    var jsFiles = v.getFilteredFileList(tempName + '/js', /\.js$/, /js\/tests\//),
+                    var jsFiles = v.getFilteredFileList(tempName + '/js', /\.js$/, /js[\/\\]tests[\/\\]/),
                         promises = [];
 
                     jsFiles.forEach(function (file) {


### PR DESCRIPTION
Bootstrap tests were not filtered because windows uses backslashes as directory seperator.
