### PR TITLE
Update regex for almond script insertion 

### DIFF
--- a/volofile
+++ b/volofile
@@ -87,7 +87,7 @@ module.exports = {
                     if (!namedArgs.dynamic) {
                         var indexName = buildDir + '/index.html',
                             contents = v.read(indexName),
-                            scriptRegExp = /(<script[^>]+data-main="[^"]+"[^>]+)(src="[^"]+")([^>]+>\s*<\/script>)/;
+                            scriptRegExp = /(<script[^>]+data-main="[^"]+"[^>]+)(src="[^"]+")([^>]*>\s*<\/script>)/;
 
                         contents = contents.replace(scriptRegExp,
                             function (match, pre, script, post) {


### PR DESCRIPTION
There is minor issue with regex for almond script insertion, it seeks at least one char after `src` attribute and its value, so I changed it to seek none or more chars, now the script tag looks more robust.
